### PR TITLE
Automated update of search head status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,19 @@ used or `OUT` if the load balancer should NOT use it.
 
 The endpoint does not need authentication.
 
+Macros are provided to manually change cluster member status
+
+Saved search monitors and updates member status
+
 **Install:**
 
 Install as usual in the Splunk web or copy into $SPLUNK_HOME/etc/apps
+Install or link to etc/shcluster/apps on SHC Deployer for distribution
 
 **Configure:**
 
 The TA provides a saved search to populate the lookup with the names of the SH's.
-This saved search is disabled by default.
+Saved searches are disabled by default.
 
 **Debug**
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Install or link to etc/shcluster/apps on SHC Deployer for distribution
 The TA provides a saved search to populate the lookup with the names of the SH's.
 Saved searches are disabled by default.
 
+The automated status update search requires configuration of a macro
+`lb_splunk_searchheads` defaults to "splunk_server=*splunksh*"
+
 **Debug**
 
 Debug option can be enabled in the script handler `LoadBalancerStatus.py` by

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The TA provides a saved search to populate the lookup with the names of the SH's
 Saved searches are disabled by default.
 
 The automated status update search requires configuration of a macro
-`lb_splunk_searchheads` defaults to "splunk_server=*splunksh*"
+\`lb_splunk_searchheads\` defaults to "splunk_server=\*splunksh\*"
 
 **Debug**
 

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -11,3 +11,7 @@ iseval = 0
 [lb_status]
 definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer
 iseval = 0
+
+[lb_splunk_searchheads]
+definition splunk_server=*splunksh*
+iseval = 0

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -8,11 +8,6 @@ args = host
 definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer | eval value=if(splunk_server="$host$", "OUT", value) | outputlookup loadbalancer
 iseval = 0
 
-[lb_sh_status(2)]
-args = host,shstatus
-definition =  append [| inputlookup append=t loadbalancer |search splunk_server!=$host$ ]| eval value=if(splunk_server="$host$", shstatus, value) | table splunk_server value | outputlookup loadbalancer
-iseval = 0
-
 [lb_status]
 definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer
 iseval = 0

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -8,6 +8,11 @@ args = host
 definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer | eval value=if(splunk_server="$host$", "OUT", value) | outputlookup loadbalancer
 iseval = 0
 
+[lb_sh_status(2)]
+args = host,shstatus
+definition =  append [| inputlookup append=t loadbalancer |search splunk_server!=$host$ ]| eval value=if(splunk_server="$host$", shstatus, value) | table splunk_server value | outputlookup loadbalancer
+iseval = 0
+
 [lb_status]
 definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer
 iseval = 0

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -13,5 +13,5 @@ definition = index=0-0 earliest=-1s | inputlookup append=t loadbalancer
 iseval = 0
 
 [lb_splunk_searchheads]
-definition splunk_server=*splunksh*
+definition = splunk_server=*splunksh*
 iseval = 0

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -26,4 +26,25 @@ display.page.search.tab = statistics
 enableSched = 1
 request.ui_dispatch_app = SA-LoadBalancerStatus
 request.ui_dispatch_view = search
-search = | rest /services/shcluster/member/info splunk_server=local |  table splunk_server maintenance_mode status |  rename splunk_server as host |  eval shstatus=if(maintenance_mode=="0" AND status=="Up" AND is_registered=="1","IN","OUT")  |  `lb_sh_status(host,shstatus)`
+search = | rest /services/shcluster/status advanced=1 splunk_server=*splunksh*  \
+| table peers*status peers*manual_detention peers*.label  \
+| stats values(*) AS *  \
+| transpose  \
+| rex field=column ".*\.(?<peer_id>[^\.]+)\.(?<field>.*)"  \
+| rename "row 1" AS value  \
+| fields - column  \
+| eval mash=field + "." + value  \
+| stats values(mash) AS mashed by peer_id  \
+| fields mashed  \
+| rex field=mashed "label\.(?<splunk_server>.*)"  \
+| rex field=mashed "manual_detention\.(?<manual_detention>.*)"  \
+| rex field=mashed "status\.(?<status>.*)"  \
+| fields - mashed  \
+| table splunk_server status manual_detention  \
+| append  \
+    [| inputlookup append=t loadbalancer  \
+        ]  \
+| dedup splunk_server  \
+| eval value=if(manual_detention=="off" AND status=="Up","IN","OUT")  \
+| table splunk_server value  \
+| outputlookup loadbalancer

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -26,7 +26,7 @@ display.page.search.tab = statistics
 enableSched = 1
 request.ui_dispatch_app = SA-LoadBalancerStatus
 request.ui_dispatch_view = search
-search = | rest /services/shcluster/status advanced=1 splunk_server=*splunksh*  \
+search = | rest /services/shcluster/status advanced=1 `lb_splunk_searchheads`  \
 | table peers*status peers*manual_detention peers*.label  \
 | stats values(*) AS *  \
 | transpose  \

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -9,6 +9,21 @@ display.general.timeRangePicker.show = 0
 display.general.type = statistics
 display.page.search.tab = statistics
 enableSched = 1
-request.ui_dispatch_app = TA-LoadBalancerStatus
+request.ui_dispatch_app = SA-LoadBalancerStatus
 request.ui_dispatch_view = search
 search = index=_internal sourcetype=splunkd_remote_searches server=* | stats count by server | rename server AS splunk_server | inputlookup append=t loadbalancer | eval value=if(isnotnull(value), value, "IN") | fields - count | dedup splunk_server | outputlookup loadbalancer
+
+[REST endpoint for Load Balancer Status - SH status update]
+disabled = 1
+action.email.useNSSubject = 1
+alert.track = 0
+cron_schedule = * * * * *
+dispatch.earliest_time = -1s
+dispatch.latest_time = now
+display.general.timeRangePicker.show = 0
+display.general.type = statistics
+display.page.search.tab = statistics
+enableSched = 1
+request.ui_dispatch_app = SA-LoadBalancerStatus
+request.ui_dispatch_view = search
+search = | rest /services/shcluster/member/info splunk_server=local |  table splunk_server maintenance_mode status |  rename splunk_server as host |  eval shstatus=if(maintenance_mode=="0" AND status=="Up" AND is_registered=="1","IN","OUT")  |  `lb_sh_status(host,shstatus)`

--- a/local/app.conf
+++ b/local/app.conf
@@ -1,0 +1,10 @@
+[install]
+state = enabled
+
+[ui]
+is_visible = 1
+
+[launcher]
+
+[package]
+check_for_updates = 1

--- a/local/savedsearches.conf
+++ b/local/savedsearches.conf
@@ -1,0 +1,7 @@
+[REST endpoint for Load Balancer Status - SH status update]
+disabled = 1
+enableSched = 0
+
+[REST endpoint for Load Balancer Status - lookup - gen]
+disabled = 1
+enableSched = 0


### PR DESCRIPTION
Added a search to automatically update search head status.

also some pedantic edits

Caveats: 
Cron only allows updates once a minute, which is not really fast enough for a LB

Testing shows that with furious running of the search that auto-updates status during an shcluster-apply, that there is a brief point where all sh are "OUT" and a few seconds where only one (of three) sh is available.

